### PR TITLE
rel:' nofollow' adds to link when using Padrino

### DIFF
--- a/lib/simple_navigation_renderers/rendered_item.rb
+++ b/lib/simple_navigation_renderers/rendered_item.rb
@@ -103,7 +103,7 @@ module SimpleNavigationRenderers
       end
 
       def simple_link
-        link_options[:method] ||= item.method
+        link_options[:method] ||= item.method if item.method
         link_to(item.name, (item.url || "#"), link_options)
       end
 


### PR DESCRIPTION
To avoid Padrino tag helpers adding the attribute when a key :method is found (https://github.com/padrino/padrino-framework/blob/master/padrino-helpers/lib/padrino-helpers/tag_helpers.rb#L288), better to make this line conditional.
