### PR TITLE
Submenu without split is rendered escaped

### DIFF
--- a/lib/simple_navigation_renderers/rendered_item.rb
+++ b/lib/simple_navigation_renderers/rendered_item.rb
@@ -59,7 +59,7 @@ module SimpleNavigationRenderers
             if split
               splitted_simple_part + splitted_dropdown_part
             else
-              dropdown_part( item.name + ' ' + caret )
+              dropdown_part( (item.name + ' ' + caret).html_safe )
             end
           else
             content_tag(:li, dropdown_submenu_link, options)


### PR DESCRIPTION
Hello,

using submenu without `split: true` option leads to html output with escaped `&amp;b class='caret'`.

This pr fixes that problem.
